### PR TITLE
Support pasting full token URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # twitchindicator
 
-Displays active streams from channels you're following on twitch.
+Displays active streams from channels you're following on Twitch.
 Now it's a beta version, so don't hesitate to report bugs and request some improvements.
 
 
@@ -10,6 +10,6 @@ Click the "Relogin" button in the widget configuration
 Your default browser will open to the Twitch authentication page
 After logging in, you'll be redirected to a URL like: http://localhost/#access_token=TTTTTTTTTTTTTTTTTTT&scope=user%3Aread%3Afollows&token_type=bearer
 
-Copy the token (the part after access_token= and before &scope=)
+Copy the entire URL
 
-Paste the token into the text field and click "Save Token"
+Paste it into the text field and click "Save Token" (the widget will extract the token automatically)

--- a/package/contents/ui/ConfigGeneral.qml
+++ b/package/contents/ui/ConfigGeneral.qml
@@ -59,16 +59,26 @@ Item {
 
 	RowLayout {
           spacing: 8
-    	  TextField {
-	        id: manualToken
-        	placeholderText: "Paste your Twitch token here"
-        	Layout.fillWidth: true
-    	  }
-    	  Button {
-        	text: "Save Token"
+          TextField {
+                id: manualToken
+                placeholderText: "Paste your Twitch token or URL here"
+                Layout.fillWidth: true
+          }
+          Button {
+                text: "Save Token"
           onClicked: {
-            authFlow.cfg_twitchToken = manualToken.text;
-            console.log("Manually pasted token: " + manualToken.text);
+            var input = manualToken.text.trim();
+            if (input.indexOf("access_token=") !== -1) {
+                var tokenData = input.substring(input.indexOf("access_token=") + "access_token=".length);
+                var ampIndex = tokenData.indexOf("&");
+                if (ampIndex !== -1) {
+                    tokenData = tokenData.substring(0, ampIndex);
+                }
+                authFlow.cfg_twitchToken = tokenData;
+            } else {
+                authFlow.cfg_twitchToken = input;
+            }
+            console.log("Manually pasted token: " + authFlow.cfg_twitchToken);
             Plasmoid.configuration.twitchToken = authFlow.cfg_twitchToken;
            }
          }

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -32,7 +32,7 @@ PlasmoidItem {
 				cb(body);
 			}
 			else {
-				log("Failed to execure the request: status code is not 200", {method: method, url: url, options: options, request: xhr});
+                                log("Failed to execute the request: status code is not 200", {method: method, url: url, options: options, request: xhr});
 			}
 		}
 		xhr.onerror = function(e) {


### PR DESCRIPTION
## Summary
- allow manual token input to accept entire OAuth URL and extract the token
- update README instructions accordingly
- fix typo in `main.qml`

## Testing
- `bash build.sh`

------
https://chatgpt.com/codex/tasks/task_e_687a030944588330a2d5725cc7dd2a79